### PR TITLE
Verify multiple attestations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "merkleTrees"]
+	path = merkleTrees
+	url = git@github.com:BigWhaleLabs/ketl-merkle-trees.git

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docker-update-image": "docker build -t bigwhalelabs/attestor -f Dockerfile.backend.production . && docker push bigwhalelabs/attestor"
   },
   "dependencies": {
-    "@big-whale-labs/constants": "^0.1.73",
+    "@big-whale-labs/constants": "^0.2.15",
     "@big-whale-labs/ketl-email": "^0.1.15",
     "@big-whale-labs/seal-cred-email": "^1.1.2",
     "@hapi/boom": "^10.0.0",

--- a/src/controllers/verify-ketl.ts
+++ b/src/controllers/verify-ketl.ts
@@ -1,9 +1,10 @@
 import { Body, Controller, Ctx, Post } from 'amala'
 import { Context } from 'vm'
-import { badRequest } from '@hapi/boom'
+import { badRequest, notFound } from '@hapi/boom'
 import { ethers } from 'ethers'
 import { polygonProvider } from '@/helpers/providers'
 import AttestationType from '@/validators/AttestationType'
+import AttestationTypeList from '@/validators/AttestationTypeList'
 import BalanceUniqueVerifyBody from '@/validators/BalanceUniqueVerifyBody'
 import Email from '@/validators/Email'
 import Signature from '@/validators/Signature'
@@ -11,6 +12,7 @@ import Token from '@/validators/Token'
 import TwitterBody from '@/validators/TwitterBody'
 import VerificationType from '@/models/VerificationType'
 import fetchUserProfile from '@/helpers/twitter/fetchUserProfile'
+import getAllowlistMap from '@/helpers/getAllowlistMap'
 import getBalance from '@/helpers/getBalance'
 import getEmailDomain from '@/helpers/getEmailDomain'
 import hexlifyString from '@/helpers/hexlifyString'
@@ -18,30 +20,66 @@ import sendEmail from '@/helpers/sendEmail'
 import signAttestationMessage from '@/helpers/signatures/signAttestationMessage'
 import zeroAddress from '@/models/zeroAddress'
 
+const allowlistMap = getAllowlistMap()
 @Controller('/verify-ketl')
 export default class VerifyKetlController {
   @Post('/token')
-  token(@Body({ required: true }) { token, type }: AttestationType & Token) {
-    return signAttestationMessage(type, hexlifyString(token))
+  token(
+    @Ctx() ctx: Context,
+    @Body({ required: true }) { token, types }: AttestationTypeList & Token
+  ) {
+    const attestations = []
+    for (const type of types) {
+      const allowlist = allowlistMap.get(type)
+      if (allowlist?.has(`token:${token}`))
+        attestations.push(signAttestationMessage(type, hexlifyString(token)))
+    }
+
+    if (!attestations.length)
+      return ctx.throw(
+        notFound(
+          `Couldn't find the invitation for this token. Please, try another one`
+        )
+      )
+    return Promise.all(attestations)
   }
 
   @Post('/email-unique')
   async sendUniqueEmail(
+    @Ctx() ctx: Context,
     @Body({ required: true })
-    { email, type }: AttestationType & Email
+    { email, types }: AttestationTypeList & Email
   ) {
-    const { message, signature } = await signAttestationMessage(
-      type,
-      VerificationType.email,
-      hexlifyString(email)
-    )
-    const domain = getEmailDomain(email)
-    const attestationHash = message[1]
+    const secret = []
 
+    for (const type of types) {
+      const allowlist = allowlistMap.get(type)
+      console.log(allowlist)
+      if (!allowlist?.has(`email:${email}`)) continue
+      const { message, signature } = await signAttestationMessage(
+        type,
+        VerificationType.email,
+        hexlifyString(email)
+      )
+      if (secret.length === 0) {
+        const attestationHash = message[1]
+        secret.push(attestationHash)
+      }
+      secret.push(`${type}${signature}`)
+    }
+
+    if (!secret.length)
+      return ctx.throw(
+        notFound(
+          `Couldn't find the invitation for this email address. Please, try another one`
+        )
+      )
+
+    const domain = getEmailDomain(email)
     void sendEmail({
       domain,
       forKetl: true,
-      secret: `${type}${attestationHash}${signature}`,
+      secret: secret.join(''),
       subject: "Here's your token!",
       to: email,
     })
@@ -50,12 +88,28 @@ export default class VerifyKetlController {
   @Post('/twitter')
   async twitter(
     @Ctx() ctx: Context,
-    @Body({ required: true }) { token, type }: TwitterBody & AttestationType
+    @Body({ required: true })
+    { token, types }: TwitterBody & AttestationTypeList
   ) {
     try {
       const { id } = await fetchUserProfile(token)
 
-      return signAttestationMessage(type, VerificationType.twitter, id)
+      const attestations = []
+      for (const type of types) {
+        const allowlist = allowlistMap.get(type)
+        if (allowlist?.has(`twitter:${id}`))
+          attestations.push(
+            signAttestationMessage(type, VerificationType.twitter, id)
+          )
+      }
+
+      if (!attestations.length)
+        return ctx.throw(
+          notFound(
+            `Couldn't find the invitation for this Twitter handle. Please, try another one`
+          )
+        )
+      return Promise.all(attestations)
     } catch (e) {
       console.error(e)
       return ctx.throw(badRequest('Failed to fetch user profile'))

--- a/src/controllers/verify-ketl.ts
+++ b/src/controllers/verify-ketl.ts
@@ -21,6 +21,7 @@ import signAttestationMessage from '@/helpers/signatures/signAttestationMessage'
 import zeroAddress from '@/models/zeroAddress'
 
 const allowlistMap = getAllowlistMap()
+
 @Controller('/verify-ketl')
 export default class VerifyKetlController {
   @Post('/token')

--- a/src/controllers/verify-ketl.ts
+++ b/src/controllers/verify-ketl.ts
@@ -20,6 +20,7 @@ import fetchUserProfile from '@/helpers/twitter/fetchUserProfile'
 import getAllowlistMap from '@/helpers/getAllowlistMap'
 import getBalance from '@/helpers/getBalance'
 import getEmailDomain from '@/helpers/getEmailDomain'
+import handleInvitationError from '@/helpers/handleInvitationError'
 import hexlifyString from '@/helpers/hexlifyString'
 import sendEmail from '@/helpers/sendEmail'
 import signAttestationMessage from '@/helpers/signatures/signAttestationMessage'
@@ -43,11 +44,7 @@ export default class VerifyKetlController {
     }
 
     if (!attestations.length)
-      return ctx.throw(
-        notFound(
-          "Couldn't find the invitation for this token. Please, try another one"
-        )
-      )
+      return ctx.throw(notFound(handleInvitationError('token')))
     return Promise.all(attestations)
   }
 
@@ -81,11 +78,7 @@ export default class VerifyKetlController {
     }
 
     if (!secret.length)
-      return ctx.throw(
-        notFound(
-          "Couldn't find the invitation for this email address. Please, try another one"
-        )
-      )
+      return ctx.throw(notFound(handleInvitationError('email')))
 
     const domain = getEmailDomain(email)
     void sendEmail({
@@ -141,11 +134,7 @@ export default class VerifyKetlController {
     }
 
     if (!attestations.length)
-      return ctx.throw(
-        notFound(
-          `Couldn't find the invitation for this Twitter handle. Please, try another one`
-        )
-      )
+      return ctx.throw(notFound(handleInvitationError('Twitter handle')))
 
     return Promise.all(attestations)
   }
@@ -228,11 +217,7 @@ export default class VerifyKetlController {
         )
     }
     if (!attestations.length)
-      return ctx.throw(
-        notFound(
-          `Couldn't find the invitation for this wallet. Please, try another one`
-        )
-      )
+      return ctx.throw(notFound(handleInvitationError('Twitter wallet')))
     return Promise.all(attestations)
   }
 

--- a/src/controllers/verify-ketl.ts
+++ b/src/controllers/verify-ketl.ts
@@ -40,7 +40,7 @@ export default class VerifyKetlController {
     if (!attestations.length)
       return ctx.throw(
         notFound(
-          `Couldn't find the invitation for this token. Please, try another one`
+          "Couldn't find the invitation for this token. Please, try another one"
         )
       )
     return Promise.all(attestations)
@@ -78,7 +78,7 @@ export default class VerifyKetlController {
     if (!secret.length)
       return ctx.throw(
         notFound(
-          `Couldn't find the invitation for this email address. Please, try another one`
+          "Couldn't find the invitation for this email address. Please, try another one"
         )
       )
 
@@ -136,7 +136,7 @@ export default class VerifyKetlController {
       if (!attestations.length)
         return ctx.throw(
           notFound(
-            `Couldn't find the invitation for this Twitter handle. Please, try another one`
+            "Couldn't find the invitation for this Twitter handle. Please, try another one"
           )
         )
       return Promise.all(attestations)

--- a/src/helpers/getAllowlistMap.ts
+++ b/src/helpers/getAllowlistMap.ts
@@ -1,0 +1,31 @@
+import * as fs from 'fs'
+import { resolve } from 'path'
+import AttestationType from '@/models/AttestationType'
+
+function getAllowlist(attestationType: AttestationType) {
+  try {
+    const filePath = resolve(
+      process.cwd(),
+      'merkleTrees',
+      `${attestationType}.txt`
+    )
+    const file = fs.readFileSync(filePath, 'utf8')
+    const allowlist = file.split('\n')
+    const filteredAllowlist = allowlist.filter(
+      (record: string) => !/^#/.test(record) && record !== ''
+    )
+    return filteredAllowlist
+  } catch (e) {
+    return []
+  }
+}
+
+export default function getAllowlistMap(): Map<AttestationType, Set<string>> {
+  const allowlistMap = new Map()
+  for (const type in AttestationType) {
+    const attestationType = Number(type)
+    if (isNaN(attestationType)) continue
+    allowlistMap.set(attestationType, new Set(getAllowlist(attestationType)))
+  }
+  return allowlistMap
+}

--- a/src/helpers/getAllowlistMap.ts
+++ b/src/helpers/getAllowlistMap.ts
@@ -11,10 +11,9 @@ function getAllowlist(attestationType: AttestationType) {
     )
     const file = fs.readFileSync(filePath, 'utf8')
     const allowlist = file.split('\n')
-    const filteredAllowlist = allowlist.filter(
+    return allowlist.filter(
       (record: string) => !/^#/.test(record) && record !== ''
     )
-    return filteredAllowlist
   } catch (e) {
     return []
   }

--- a/src/helpers/handleInvitationError.ts
+++ b/src/helpers/handleInvitationError.ts
@@ -1,0 +1,3 @@
+export default function (type: string) {
+  return `Couldn't find the invitation for this ${type}. Please, try another one`
+}

--- a/src/helpers/twitter/fetchUserProfile.ts
+++ b/src/helpers/twitter/fetchUserProfile.ts
@@ -2,14 +2,18 @@ import TwitterProfile from '@/models/TwitterProfile'
 import axios from 'axios'
 
 export default async function fetchUserProfile(token: string) {
-  const { data } = await axios.get<TwitterProfile>(
-    'https://api.twitter.com/2/users/me',
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
-  )
+  try {
+    const { data } = await axios.get<TwitterProfile>(
+      'https://api.twitter.com/2/users/me',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
 
-  return data.data
+    return data.data
+  } catch (e) {
+    return null
+  }
 }

--- a/src/validators/AttestationTypeList.ts
+++ b/src/validators/AttestationTypeList.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'amala'
+import AttestationType from '@/models/AttestationType'
+
+export default class {
+  @IsEnum(AttestationType, { each: true })
+  types!: AttestationType[]
+}

--- a/src/validators/OrangeDAOTokenAddress.ts
+++ b/src/validators/OrangeDAOTokenAddress.ts
@@ -1,0 +1,11 @@
+import { IsEthereumAddress, IsIn } from 'amala'
+import {
+  KETL_BWL_NFT_CONTRACT,
+  YC_ALUM_NFT_CONTRACT,
+} from '@big-whale-labs/constants'
+
+export default class {
+  @IsEthereumAddress()
+  @IsIn([KETL_BWL_NFT_CONTRACT, YC_ALUM_NFT_CONTRACT])
+  tokenAddress?: string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@big-whale-labs/constants@npm:^0.1.73":
-  version: 0.1.73
-  resolution: "@big-whale-labs/constants@npm:0.1.73"
-  checksum: 4ef845aa29b362748c6de31077d788c45fd2b38e2144d95e221ddc449776bbc4df085ea500d172ffc4048d7a42f8c8839017797a6d286411c025f7d467be9ea8
+"@big-whale-labs/constants@npm:^0.2.15":
+  version: 0.2.15
+  resolution: "@big-whale-labs/constants@npm:0.2.15"
+  checksum: d67041f388f80d807e19d8360754cc3b72db6ba3673951a5b6553b774ab3bbf77d7e699ffff9aae27d4d5f39837657e63313f7f0f7e6f94639f63a0ee2cbb6b4
   languageName: node
   linkType: hard
 
@@ -1712,7 +1712,7 @@ __metadata:
   resolution: "attestor@workspace:."
   dependencies:
     "@big-whale-labs/bwl-eslint-backend": ^1.0.3
-    "@big-whale-labs/constants": ^0.1.73
+    "@big-whale-labs/constants": ^0.2.15
     "@big-whale-labs/ketl-email": ^0.1.15
     "@big-whale-labs/prettier-config": ^1.1.3
     "@big-whale-labs/seal-cred-email": ^1.1.2


### PR DESCRIPTION
Attestor now accepts an array of AttestationTypes, checks allowlists of the specified attestationTypes and returns an array of signatures (or emails with a string representing multiple signatures). 